### PR TITLE
Add regex to catch errors without file/line information

### DIFF
--- a/expected.txt
+++ b/expected.txt
@@ -1,9 +1,12 @@
 <?xml version="1.0"?>
-<testsuite name="Typescript type errors" tests="2" failures="2">
+<testsuite name="Typescript type errors" tests="3" failures="3">
   <testcase name="TS2551" classname="index.js:34:30">
     <failure type="TS2551" message="Property 'TracingDataset' does not exist on type 'Options'. Did you mean 'TracingDatase'?"/>
   </testcase>
   <testcase name="TS2345" classname="index.test.js:52:5">
     <failure type="TS2345" message="Argument of type '{ APIHost: string; APIKey: string; GlobalMetadata: { global: string; }; DesiredSampleRate: number; TracingDataset: string; }' is not assignable to parameter of type 'Options | &quot;mock&quot;'."/>
+  </testcase>
+  <testcase name="TS2688" classname="N/A:N/A:N/A">
+    <failure type="TS2688" message="Cannot find type definition file for 'ember__test-helpers'."/>
   </testcase>
 </testsuite>

--- a/main.js
+++ b/main.js
@@ -50,6 +50,7 @@ async function main(input, output) {
 
 // We only handle the format without --pretty right now
 const UGLY_REGEX = /^(?<file>.+?)\((?<line>\d+),(?<col>\d+)\): error (?<code>\S+?): (?<message>.+)$/;
+const ERROR_WITHOUT_FILE_REGEX = /error (?<code>\S+?): (?<message>.+)$/;
 
 /**
  * @returns {Parser}
@@ -58,15 +59,24 @@ function newParser() {
   const errors = [];
   function parse(line) {
     const match = UGLY_REGEX.exec(line);
+    const errorWithoutFileMatch = ERROR_WITHOUT_FILE_REGEX.exec(line);
+
     if (match) {
       errors.push({
         filename: match.groups.file,
         line: Number(match.groups.line),
         col: Number(match.groups.col),
         code: match.groups.code,
-        message: match.groups.message
-      })
-      return;
+        message: match.groups.message,
+      });
+    } else if (errorWithoutFileMatch) {
+      errors.push({
+        code: errorWithoutFileMatch.groups.code,
+        col: 'N/A',
+        filename: 'N/A',
+        line: 'N/A',
+        message: errorWithoutFileMatch.groups.message,
+      });
     }
   }
   return {errors, parse};

--- a/sample.txt
+++ b/sample.txt
@@ -1,3 +1,4 @@
 index.js(34,30): error TS2551: Property 'TracingDataset' does not exist on type 'Options'. Did you mean 'TracingDatase'?
 index.test.js(52,5): error TS2345: Argument of type '{ APIHost: string; APIKey: string; GlobalMetadata: { global: string; }; DesiredSampleRate: number; TracingDataset: string; }' is not assignable to parameter of type 'Options | "mock"'.
   Object literal may only specify known properties, but 'TracingDataset' does not exist in type 'Options'. Did you mean to write 'TracingDatase'?
+error TS2688: Cannot find type definition file for 'ember__test-helpers'.


### PR DESCRIPTION
We discovered that in some instances, Typescript will return an error that isn't associated with a specific file, line, or col.

For example:
`error TS2688: Cannot find type definition file for 'ember__test-helpers'.`

In these cases, typescript-xunit-xml was returning a result which looked identical to a passing `tsc` compile (0 errors), and our builds were passing when they shouldn't.

At least for our use case, it would be really helpful to report out those errors as well. Is that something the broader community might want? Here's one proposal to fix that, which introduces a separate regex to catch the errors.

